### PR TITLE
Bugfix: ERC20Wrapper underlying variable is public

### DIFF
--- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
@@ -16,17 +16,17 @@ import "../utils/SafeERC20.sol";
  * _Available since v4.2._
  */
 abstract contract ERC20Wrapper is ERC20 {
-    IERC20 public immutable underlying;
+    IERC20 immutable _underlying;
 
     constructor(IERC20 underlyingToken) {
-        underlying = underlyingToken;
+        _underlying = underlyingToken;
     }
 
     /**
      * @dev See {ERC20-decimals}.
      */
     function decimals() public view virtual override returns (uint8) {
-        try IERC20Metadata(address(underlying)).decimals() returns (uint8 value) {
+        try IERC20Metadata(address(_underlying)).decimals() returns (uint8 value) {
             return value;
         } catch {
             return super.decimals();
@@ -37,7 +37,7 @@ abstract contract ERC20Wrapper is ERC20 {
      * @dev Allow a user to deposit underlying tokens and mint the corresponding number of wrapped tokens.
      */
     function depositFor(address account, uint256 amount) public virtual returns (bool) {
-        SafeERC20.safeTransferFrom(underlying, _msgSender(), address(this), amount);
+        SafeERC20.safeTransferFrom(_underlying, _msgSender(), address(this), amount);
         _mint(account, amount);
         return true;
     }
@@ -47,7 +47,7 @@ abstract contract ERC20Wrapper is ERC20 {
      */
     function withdrawTo(address account, uint256 amount) public virtual returns (bool) {
         _burn(_msgSender(), amount);
-        SafeERC20.safeTransfer(underlying, account, amount);
+        SafeERC20.safeTransfer(_underlying, account, amount);
         return true;
     }
 
@@ -56,7 +56,7 @@ abstract contract ERC20Wrapper is ERC20 {
      * function that can be exposed with access control if desired.
      */
     function _recover(address account) internal virtual returns (uint256) {
-        uint256 value = underlying.balanceOf(address(this)) - totalSupply();
+        uint256 value = _underlying.balanceOf(address(this)) - totalSupply();
         _mint(account, value);
         return value;
     }

--- a/contracts/token/ERC20/extensions/ERC20Wrapper.sol
+++ b/contracts/token/ERC20/extensions/ERC20Wrapper.sol
@@ -34,6 +34,13 @@ abstract contract ERC20Wrapper is ERC20 {
     }
 
     /**
+     * @dev Returns the address of the ERC-20 token deployed with ERC20Wrapper.sol
+     */
+    function underlying() public view returns (IERC20) {
+        return _underlying;
+    }
+
+    /**
      * @dev Allow a user to deposit underlying tokens and mint the corresponding number of wrapped tokens.
      */
     function depositFor(address account, uint256 amount) public virtual returns (bool) {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes https://github.com/OpenZeppelin/openzeppelin-contracts/issues/4026

<!-- Describe the changes introduced in this pull request. -->
## Changes
- Removed the public visibility from `IERC20 immutable _underlying;` and refactored it to include the `_ ` due to linting errors.
- Implemented the `underlying() public view` function to return the value of the `_underlying` variable.
- Verified all unit tests pass including the ERC20Wrapper tests that reference the `underlying` function.
<!-- Include any context necessary for understanding the PR's purpose. -->

## Visual Preview

<img width="337" alt="Screen Shot 2023-02-04 at 9 35 43 AM" src="https://user-images.githubusercontent.com/42893948/216773231-ce0ec8b9-11c2-46c2-b077-6c48a27d6cf2.png">

<img width="755" alt="Screen Shot 2023-02-04 at 9 35 20 AM" src="https://user-images.githubusercontent.com/42893948/216773211-ccc834b2-aca1-4498-beba-dac6c5b7216e.png">


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Tests
- [x] Documentation
- [ ] Changeset entry (run `npx changeset add`)
